### PR TITLE
Change all use of "CAM" to EAM for new E3SM version

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2019 UT-BATTELLE, LLC
+Copyright (c) 2018-2021 UT-BATTELLE, LLC
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/evv4esm/__init__.py
+++ b/evv4esm/__init__.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright (c) 2018 UT-BATTELLE, LLC
+# Copyright (c) 2018-2021 UT-BATTELLE, LLC
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -29,7 +29,7 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-__version_info__ = (0, 2, 1)
+__version_info__ = (0, 2, 3)
 __version__ = '.'.join(str(vi) for vi in __version_info__)
 
 PASS_COLOR = '#389933'

--- a/evv4esm/ensembles/e3sm.py
+++ b/evv4esm/ensembles/e3sm.py
@@ -47,7 +47,7 @@ from netCDF4 import Dataset
 def component_file_instance(component, case_file):
     search_regex = r'{c}_[0-9]+'.format(c=component)
     result = re.search(search_regex, case_file).group(0)
-    return int(result.replace('cam_', ''))
+    return int(result.replace('{}_'.format(component), ''))
 
 
 def file_date_str(case_file, style='short'):

--- a/evv4esm/ensembles/e3sm.py
+++ b/evv4esm/ensembles/e3sm.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # coding=utf-8
-# Copyright (c) 2018 UT-BATTELLE, LLC
+# Copyright (c) 2018-2021 UT-BATTELLE, LLC
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/evv4esm/extensions/ks.py
+++ b/evv4esm/extensions/ks.py
@@ -199,8 +199,8 @@ def case_files(args):
         key1 += '1'
         key2 += '2'
 
-    f_sets = {key1: e3sm.component_monthly_files(args.test_dir, 'cam', args.ninst),
-              key2: e3sm.component_monthly_files(args.ref_dir, 'cam', args.ninst)}
+    f_sets = {key1: e3sm.component_monthly_files(args.test_dir, 'eam', args.ninst),
+              key2: e3sm.component_monthly_files(args.ref_dir, 'eam', args.ninst)}
 
     for key in f_sets:
         # Require case files for at least the last 12 months.

--- a/evv4esm/extensions/ks.py
+++ b/evv4esm/extensions/ks.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # coding=utf-8
-# Copyright (c) 2018 UT-BATTELLE, LLC
+# Copyright (c) 2018-2021 UT-BATTELLE, LLC
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/evv4esm/extensions/pg.py
+++ b/evv4esm/extensions/pg.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # coding=utf-8
-# Copyright (c) 2015,2016, UT-BATTELLE, LLC
+# Copyright (c) 2015-2021 UT-BATTELLE, LLC
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/evv4esm/extensions/pg.py
+++ b/evv4esm/extensions/pg.py
@@ -139,7 +139,7 @@ def rmse_writer(file_name, rmse, perturbation_names, perturbation_variables, ini
 
         for icond in range(0, ninit):
             # NOTE: Zero vs One based indexing
-            nc_init_cond[icond] = init_file_template.format('cam', 'i', icond+1)
+            nc_init_cond[icond] = init_file_template.format('eam', 'i', icond+1)
 
 
 def variables_rmse(ifile_test, ifile_cntl, var_list, var_pefix=''):

--- a/evv4esm/extensions/tsc.py
+++ b/evv4esm/extensions/tsc.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # coding=utf-8
-# Copyright (c) 2015,2016, UT-BATTELLE, LLC
+# Copyright (c) 2015-2021 UT-BATTELLE, LLC
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/evv4esm/extensions/tsc.py
+++ b/evv4esm/extensions/tsc.py
@@ -163,14 +163,13 @@ def main(args):
         args.test_case += '1'
         args.ref_case += '2'
 
-    file_search_glob_ref = '{d}/*eam_????.h0.0001-01-01-?????.nc.{s}'
     file_search_glob = '{d}/*eam_????.h0.0001-01-01-?????.nc.{s}'
     truth_ens = {instance: list(files) for instance, files in groupby(
-            sorted(glob.glob(file_search_glob_ref.format(d=args.ref_dir, s='DT0001'))),
+            sorted(glob.glob(file_search_glob.format(d=args.ref_dir, s='DT0001'))),
             key=lambda f: e3sm.component_file_instance('eam', f))}
 
     ref_ens = {instance: list(files) for instance, files in groupby(
-            sorted(glob.glob(file_search_glob_ref.format(d=args.ref_dir, s='DT0002'))),
+            sorted(glob.glob(file_search_glob.format(d=args.ref_dir, s='DT0002'))),
             key=lambda f: e3sm.component_file_instance('eam', f))}
 
     test_ens = {instance: list(files) for instance, files in groupby(

--- a/evv4esm/extensions/tsc.py
+++ b/evv4esm/extensions/tsc.py
@@ -163,18 +163,19 @@ def main(args):
         args.test_case += '1'
         args.ref_case += '2'
 
-    file_search_glob = '{d}/*cam_????.h0.0001-01-01-?????.nc.{s}'
+    file_search_glob_ref = '{d}/*eam_????.h0.0001-01-01-?????.nc.{s}'
+    file_search_glob = '{d}/*eam_????.h0.0001-01-01-?????.nc.{s}'
     truth_ens = {instance: list(files) for instance, files in groupby(
-            sorted(glob.glob(file_search_glob.format(d=args.ref_dir, s='DT0001'))),
-            key=lambda f: e3sm.component_file_instance('cam', f))}
+            sorted(glob.glob(file_search_glob_ref.format(d=args.ref_dir, s='DT0001'))),
+            key=lambda f: e3sm.component_file_instance('eam', f))}
 
     ref_ens = {instance: list(files) for instance, files in groupby(
-            sorted(glob.glob(file_search_glob.format(d=args.ref_dir, s='DT0002'))),
-            key=lambda f: e3sm.component_file_instance('cam', f))}
+            sorted(glob.glob(file_search_glob_ref.format(d=args.ref_dir, s='DT0002'))),
+            key=lambda f: e3sm.component_file_instance('eam', f))}
 
     test_ens = {instance: list(files) for instance, files in groupby(
             sorted(glob.glob(file_search_glob.format(d=args.test_dir, s='DT0002'))),
-            key=lambda f: e3sm.component_file_instance('cam', f))}
+            key=lambda f: e3sm.component_file_instance('eam', f))}
 
     # So, we want a pandas dataframe that will have the columns :
     #     (test/ref, ensemble, seconds, l2_global, l2_land, l2_ocean)

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright (c) 2018 UT-BATTELLE, LLC
+# Copyright (c) 2018-2021 UT-BATTELLE, LLC
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
For E3SM, the name of atmosphere model component has been changed from CAM to EAM. This PR updates EVV so that reference/baseline and test filenames are correctly identified in all three non bit-for-bit tests currently run (MVK, PGN, and TSC)