### PR TITLE
Add flexibility for model component names

### DIFF
--- a/evv4esm/__init__.py
+++ b/evv4esm/__init__.py
@@ -29,7 +29,7 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-__version_info__ = (0, 2, 3)
+__version_info__ = (0, 2, 4)
 __version__ = '.'.join(str(vi) for vi in __version_info__)
 
 PASS_COLOR = '#389933'

--- a/evv4esm/extensions/ks.py
+++ b/evv4esm/extensions/ks.py
@@ -127,6 +127,10 @@ def parse_args(args=None):
                         default='eam',
                         help='Model component name (e.g. eam, cam, ...)')
 
+    parser.add_argument('--baseline-component',
+                        default='cam',
+                        help='Model component name for baseline (e.g. eam, cam, ...)')
+
     args, _ = parser.parse_known_args(args)
 
     # use config file arguments, but override with command line arguments
@@ -204,7 +208,7 @@ def case_files(args):
         key2 += '2'
 
     f_sets = {key1: e3sm.component_monthly_files(args.test_dir, args.component, args.ninst),
-              key2: e3sm.component_monthly_files(args.ref_dir, args.component, args.ninst)}
+              key2: e3sm.component_monthly_files(args.ref_dir, args.baseline_component, args.ninst)}
 
     for key in f_sets:
         # Require case files for at least the last 12 months.

--- a/evv4esm/extensions/ks.py
+++ b/evv4esm/extensions/ks.py
@@ -123,6 +123,10 @@ def parse_args(args=None):
                         default=os.getcwd(),
                         help='Image output location.')
 
+    parser.add_argument('--component',
+                        default='eam',
+                        help='Model component name (e.g. eam, cam, ...)')
+
     args, _ = parser.parse_known_args(args)
 
     # use config file arguments, but override with command line arguments
@@ -199,8 +203,8 @@ def case_files(args):
         key1 += '1'
         key2 += '2'
 
-    f_sets = {key1: e3sm.component_monthly_files(args.test_dir, 'eam', args.ninst),
-              key2: e3sm.component_monthly_files(args.ref_dir, 'eam', args.ninst)}
+    f_sets = {key1: e3sm.component_monthly_files(args.test_dir, args.component, args.ninst),
+              key2: e3sm.component_monthly_files(args.ref_dir, args.component, args.ninst)}
 
     for key in f_sets:
         # Require case files for at least the last 12 months.

--- a/evv4esm/extensions/ks.py
+++ b/evv4esm/extensions/ks.py
@@ -127,10 +127,6 @@ def parse_args(args=None):
                         default='eam',
                         help='Model component name (e.g. eam, cam, ...)')
 
-    parser.add_argument('--baseline-component',
-                        default='cam',
-                        help='Model component name for baseline (e.g. eam, cam, ...)')
-
     args, _ = parser.parse_known_args(args)
 
     # use config file arguments, but override with command line arguments
@@ -208,7 +204,7 @@ def case_files(args):
         key2 += '2'
 
     f_sets = {key1: e3sm.component_monthly_files(args.test_dir, args.component, args.ninst),
-              key2: e3sm.component_monthly_files(args.ref_dir, args.baseline_component, args.ninst)}
+              key2: e3sm.component_monthly_files(args.ref_dir, args.component, args.ninst)}
 
     for key in f_sets:
         # Require case files for at least the last 12 months.

--- a/evv4esm/extensions/pg.py
+++ b/evv4esm/extensions/pg.py
@@ -109,7 +109,7 @@ def _sub2instance(initial_condition, perturbation_index, total_perturbations):
     return instance
 
 
-def rmse_writer(file_name, rmse, perturbation_names, perturbation_variables, init_file_template):
+def rmse_writer(file_name, rmse, perturbation_names, perturbation_variables, init_file_template, model_name):
     """
     Opens and writes a netcdf file for PGE curves
     This function is here purely to avoid duplicate
@@ -139,7 +139,7 @@ def rmse_writer(file_name, rmse, perturbation_names, perturbation_variables, ini
 
         for icond in range(0, ninit):
             # NOTE: Zero vs One based indexing
-            nc_init_cond[icond] = init_file_template.format('eam', 'i', icond+1)
+            nc_init_cond[icond] = init_file_template.format(model_name, 'i', icond+1)
 
 
 def variables_rmse(ifile_test, ifile_cntl, var_list, var_pefix=''):
@@ -231,7 +231,7 @@ def main(args):
     comp_rmse = np.reshape(rmse.RMSE.values, (args.ninit, nprt-1, nvar))
 
     rmse_writer(os.path.join(args.test_dir, 'comp_cld.nc'),
-                comp_rmse, args.perturbations.keys(), args.variables, args.init_file_template)
+                comp_rmse, args.perturbations.keys(), args.variables, args.init_file_template, args.init_model)
 
     details = OrderedDict()
     with Dataset(os.path.join(args.ref_dir, args.pge_cld)) as ref_cld:

--- a/evv4esm/extensions/pg.py
+++ b/evv4esm/extensions/pg.py
@@ -214,13 +214,13 @@ def main(args):
                 continue
             iinst_ctrl = _sub2instance(icond, 0, nprt)
             ifile_ctrl = os.path.join(args.ref_dir,
-                                      args.instance_file_template.format('', iinst_ctrl, '_woprt'))
+                                      args.instance_file_template.format('', args.baseline_component, iinst_ctrl, '_woprt'))
             # logger.debug("PGN_INFO:CNTL_TST:" + ifile_cntl)
 
             iinst_test = _sub2instance(icond, iprt, nprt)
             ifile_test = os.path.join(args.test_dir,
                                       args.instance_file_template.format(
-                                              args.test_case + '.', iinst_test, '_' + prt_name))
+                                              args.test_case + '.', args.component, iinst_test, '_' + prt_name))
             # logger.debug("PGN_INFO:TEST_TST:" + ifile_test)
 
             prt_rmse[prt_name] = variables_rmse(ifile_test, ifile_ctrl, args.variables, 't_')

--- a/evv4esm/extensions/pg.py
+++ b/evv4esm/extensions/pg.py
@@ -214,7 +214,7 @@ def main(args):
                 continue
             iinst_ctrl = _sub2instance(icond, 0, nprt)
             ifile_ctrl = os.path.join(args.ref_dir,
-                                      args.instance_file_template.format('', args.baseline_component, iinst_ctrl, '_woprt'))
+                                      args.instance_file_template.format('', args.component, iinst_ctrl, '_woprt'))
             # logger.debug("PGN_INFO:CNTL_TST:" + ifile_cntl)
 
             iinst_test = _sub2instance(icond, iprt, nprt)

--- a/evv4esm/extensions/tsc.py
+++ b/evv4esm/extensions/tsc.py
@@ -165,12 +165,12 @@ def main(args):
 
     file_search_glob = '{d}/*{c}_????.h0.0001-01-01-?????.nc.{s}'
     truth_ens = {instance: list(files) for instance, files in groupby(
-            sorted(glob.glob(file_search_glob.format(d=args.ref_dir, c=args.component, s='DT0001'))),
-            key=lambda f: e3sm.component_file_instance(args.component, f))}
+            sorted(glob.glob(file_search_glob.format(d=args.ref_dir, c=args.baseline_component, s='DT0001'))),
+            key=lambda f: e3sm.component_file_instance(args.baseline_component, f))}
 
     ref_ens = {instance: list(files) for instance, files in groupby(
-            sorted(glob.glob(file_search_glob.format(d=args.ref_dir, c=args.component, s='DT0002'))),
-            key=lambda f: e3sm.component_file_instance(args.component, f))}
+            sorted(glob.glob(file_search_glob.format(d=args.ref_dir, c=args.baseline_component, s='DT0002'))),
+            key=lambda f: e3sm.component_file_instance(args.baseline_component, f))}
 
     test_ens = {instance: list(files) for instance, files in groupby(
             sorted(glob.glob(file_search_glob.format(d=args.test_dir, c=args.component, s='DT0002'))),

--- a/evv4esm/extensions/tsc.py
+++ b/evv4esm/extensions/tsc.py
@@ -163,18 +163,18 @@ def main(args):
         args.test_case += '1'
         args.ref_case += '2'
 
-    file_search_glob = '{d}/*eam_????.h0.0001-01-01-?????.nc.{s}'
+    file_search_glob = '{d}/*{c}_????.h0.0001-01-01-?????.nc.{s}'
     truth_ens = {instance: list(files) for instance, files in groupby(
-            sorted(glob.glob(file_search_glob.format(d=args.ref_dir, s='DT0001'))),
-            key=lambda f: e3sm.component_file_instance('eam', f))}
+            sorted(glob.glob(file_search_glob.format(d=args.ref_dir, c=args.component, s='DT0001'))),
+            key=lambda f: e3sm.component_file_instance(args.component, f))}
 
     ref_ens = {instance: list(files) for instance, files in groupby(
-            sorted(glob.glob(file_search_glob.format(d=args.ref_dir, s='DT0002'))),
-            key=lambda f: e3sm.component_file_instance('eam', f))}
+            sorted(glob.glob(file_search_glob.format(d=args.ref_dir, c=args.component, s='DT0002'))),
+            key=lambda f: e3sm.component_file_instance(args.component, f))}
 
     test_ens = {instance: list(files) for instance, files in groupby(
-            sorted(glob.glob(file_search_glob.format(d=args.test_dir, s='DT0002'))),
-            key=lambda f: e3sm.component_file_instance('eam', f))}
+            sorted(glob.glob(file_search_glob.format(d=args.test_dir, c=args.component, s='DT0002'))),
+            key=lambda f: e3sm.component_file_instance(args.component, f))}
 
     # So, we want a pandas dataframe that will have the columns :
     #     (test/ref, ensemble, seconds, l2_global, l2_land, l2_ocean)

--- a/evv4esm/extensions/tsc.py
+++ b/evv4esm/extensions/tsc.py
@@ -165,11 +165,11 @@ def main(args):
 
     file_search_glob = '{d}/*{c}_????.h0.0001-01-01-?????.nc.{s}'
     truth_ens = {instance: list(files) for instance, files in groupby(
-            sorted(glob.glob(file_search_glob.format(d=args.ref_dir, c=args.baseline_component, s='DT0001'))),
+            sorted(glob.glob(file_search_glob.format(d=args.ref_dir, c=args.component, s='DT0001'))),
             key=lambda f: e3sm.component_file_instance(args.baseline_component, f))}
 
     ref_ens = {instance: list(files) for instance, files in groupby(
-            sorted(glob.glob(file_search_glob.format(d=args.ref_dir, c=args.baseline_component, s='DT0002'))),
+            sorted(glob.glob(file_search_glob.format(d=args.ref_dir, c=args.component, s='DT0002'))),
             key=lambda f: e3sm.component_file_instance(args.baseline_component, f))}
 
     test_ens = {instance: list(files) for instance, files in groupby(

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ setup(
           'numpy',
           'scipy',
           'pandas',
-          'livvkit',
+          'livvkit==2.1.6',
           'netCDF4',
           'matplotlib',
           'pybtex',


### PR DESCRIPTION
To be compatible with [CIME PR 3967](https://github.com/ESMCI/cime/pull/3967), this updates evv4esm so that the model component may be dynamically set to allow E3SM and CESM to use the climate reproducibility tests