### PR TITLE
Fix TSC test passing criteria

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,11 @@ report bugs, ask questions, or contact us for any reason, use the
 
 Want to send us a private message?
 
+
 **Michael Kelleher**
 * github: @mkstratos
 * email: <a href="mailto:kelleherme@ornl.gov">kelleherme [at] ornl.gov</a>
+
 **Joseph H. Kennedy** 
 * github: @jhkennedy
 * email: <a href="mailto:kennedyjh@ornl.gov">kennedyjh [at] ornl.gov</a>

--- a/evv4esm/__init__.py
+++ b/evv4esm/__init__.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright (c) 2018-2021 UT-BATTELLE, LLC
+# Copyright (c) 2018-2022 UT-BATTELLE, LLC
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/evv4esm/__init__.py
+++ b/evv4esm/__init__.py
@@ -28,7 +28,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-__version_info__ = (0, 3, 0)
+__version_info__ = (0, 3, 1)
 __version__ = '.'.join(str(vi) for vi in __version_info__)
 
 PASS_COLOR = '#389933'

--- a/evv4esm/ensembles/e3sm.py
+++ b/evv4esm/ensembles/e3sm.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # coding=utf-8
-# Copyright (c) 2018-2021 UT-BATTELLE, LLC
+# Copyright (c) 2018-2022 UT-BATTELLE, LLC
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/evv4esm/extensions/ks.py
+++ b/evv4esm/extensions/ks.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # coding=utf-8
-# Copyright (c) 2018-2021 UT-BATTELLE, LLC
+# Copyright (c) 2018-2022 UT-BATTELLE, LLC
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/evv4esm/extensions/pg.py
+++ b/evv4esm/extensions/pg.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # coding=utf-8
-# Copyright (c) 2015-2021 UT-BATTELLE, LLC
+# Copyright (c) 2015-2022 UT-BATTELLE, LLC
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/evv4esm/extensions/tsc.py
+++ b/evv4esm/extensions/tsc.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # coding=utf-8
-# Copyright (c) 2015-2021 UT-BATTELLE, LLC
+# Copyright (c) 2015-2022 UT-BATTELLE, LLC
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/evv4esm/extensions/tsc.py
+++ b/evv4esm/extensions/tsc.py
@@ -283,8 +283,14 @@ def main(args):
         # H0: enemble_mean_ΔRMSD_{t,var} is (statistically) zero and therefore, the simulations are identical
         null_hypothesis = ttest.applymap(lambda x: 'Reject' if x[1] < args.p_threshold else 'Accept')
 
-        domains = null_hypothesis.applymap(lambda x: x == 'Reject').any().transform(
-                lambda x: 'Fail' if x is True else 'Pass')
+        domains = (
+            null_hypothesis
+            .query(' seconds >= @args.inspect_times[0] & seconds <= @args.inspect_times[-1]')
+            .applymap(lambda x: x == 'Reject').all().transform(
+                lambda x: 'Fail' if x is True else 'Pass'
+            )
+        )
+
         overall = 'Fail' if domains.apply(lambda x: x == 'Fail').any() else 'Pass'
 
         ttest.reset_index(inplace=True)
@@ -386,7 +392,7 @@ def plot_bit_for_bit(args):
 
     ax.semilogy(xx, yy + 1.0, linestyle='-', marker='o', color=pf_color_picker.get('pass'))
 
-    ax.plot(args.time_slice, [0.5, 0.5], 'k--')
+    ax.plot(args.time_slice, [args.p_threshold * 100] * 2, 'k--')
     ax.text(np.mean(args.time_slice), 10 ** -1, 'Fail', fontsize=15, color=pf_color_picker.get('fail'),
             horizontalalignment='center')
     ax.text(np.mean(args.time_slice), 0.5 * 10 ** 1, 'Pass', fontsize=15, color=pf_color_picker.get('pass'),

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright (c) 2018-2021 UT-BATTELLE, LLC
+# Copyright (c) 2018-2022 UT-BATTELLE, LLC
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
Fixes E3SM issue 4759 (https://github.com/E3SM-Project/E3SM/issues/4759)
The TSC test should fail only if all points between 300s - 600s are
below the failure threshold (`p_threshold`). This also fixes the plotting
of P_min so that the variable threshold is plotted rather than a fixed
0.5%

Plots are still generated for the times given in the `time_slice` argument,
but the test will only check the values between the fist and last `inspect_times`
argument.