### PR TITLE
Really fix TSC test passing criteria

### DIFF
--- a/evv4esm/__init__.py
+++ b/evv4esm/__init__.py
@@ -28,7 +28,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-__version_info__ = (0, 3, 1)
+__version_info__ = (0, 3, 2)
 __version__ = '.'.join(str(vi) for vi in __version_info__)
 
 PASS_COLOR = '#389933'

--- a/evv4esm/__main__.py
+++ b/evv4esm/__main__.py
@@ -59,6 +59,14 @@ def parse_args(args=None):
                                        ])
                         )
 
+    parser.add_argument('-p', '--pool-size',
+                        nargs='?',
+                        type=int,
+                        default=(options.mp.cpu_count() - 1 or 1),
+                        help='The number of multiprocessing processes to run '
+                             'analyses in. If zero, processes will run serially '
+                             'outside of the multiprocessing module.')
+
     parser.add_argument('--version',
                         action='version',
                         version='EVV {}'.format(evv4esm.__version__),
@@ -73,7 +81,6 @@ def parse_args(args=None):
     from evv4esm import resources
     args.livv_resource_dir = livvkit.resource_dir
     livvkit.resource_dir = os.sep.join(resources.__path__)
-
     return args
 
 
@@ -106,6 +113,7 @@ def main(cl_args=None):
     from livvkit.util import functions
     from livvkit import elements
 
+    livvkit.pool_size = args.pool_size
     if args.extensions:
         functions.setup_output()
         summary_elements = []

--- a/evv4esm/extensions/tsc.py
+++ b/evv4esm/extensions/tsc.py
@@ -284,14 +284,20 @@ def main(args):
         null_hypothesis = ttest.applymap(lambda x: 'Reject' if x[1] < args.p_threshold else 'Accept')
 
         domains = (
-            null_hypothesis
+            # True for rejection of null_hypothesis for each variable at each time
+            ttest.applymap(lambda x: x[1] < args.p_threshold)
+            # Select only times in the inspection window
             .query(' seconds >= @args.inspect_times[0] & seconds <= @args.inspect_times[-1]')
-            .applymap(lambda x: x == 'Reject').all().transform(
-                lambda x: 'Fail' if x is True else 'Pass'
-            )
+            # Create groups of all variables at each time step in the window
+            .groupby("seconds")
+            # Are any variables failing at each time step in the inspection window?
+            .any()
+            # Then check if all time steps in the inspection window have a failing variable
+            .all()
+            # If _all_ time steps are failing then the domain [glob, lnd, ocn] is failing
+            .transform(lambda x: "Fail" if x else "Pass")
         )
-
-        overall = 'Fail' if domains.apply(lambda x: x == 'Fail').any() else 'Pass'
+        overall = 'Fail' if domains[delta_columns].apply(lambda x: x == 'Fail').any() else 'Pass'
 
         ttest.reset_index(inplace=True)
         null_hypothesis.reset_index(inplace=True)

--- a/evv4esm/extensions/tsc.py
+++ b/evv4esm/extensions/tsc.py
@@ -402,7 +402,7 @@ def plot_bit_for_bit(args):
     failing_img_caption = (
         "The number of failing variables across both domains (land and ocean) as a "
         "function of model integration time. The dashed horizontal line represents the "
-        "failing threshold of 1 variable, the vertical dashed lines represent the inspection "
+        "failing threshold of 1 variable, the dashed vertical lines represent the inspection "
         f"window of {args.inspect_times[0]} - {args.inspect_times[-1]} s."
     )
     failing_img_link = Path(*Path(args.img_dir).parts[-2:], Path(failing_img_file).name)
@@ -443,8 +443,8 @@ def plot_bit_for_bit(args):
     pmin_img_caption = (
         "The minimum P value of all variables in both domains (land and ocean) as a "
         "function of model integration time plotted with a logarithmic y-scale. The "
-        "horizontal dashed grey line indicates the threshold for assigning an overall "
-        "pass or fail to a test ensemble; the vertical dashed lines represent the "
+        "dashed horizontal grey line indicates the threshold for assigning an overall "
+        "pass or fail to a test ensemble; the dashed vertical lines represent the "
         f"inspection window of {args.inspect_times[0]} - {args.inspect_times[-1]} s. "
         "see Wan et al. (2017) eqn. 8"
     )
@@ -481,7 +481,7 @@ def plot_failing_variables(args, null_hypothesis, img_file):
     img_caption = (
         "The number of failing variables across both domains (land and ocean) as a "
         "function of model integration time. The dashed horizontal line represents the "
-        "failing threshold of 1 variable, the vertical dashed lines represent the "
+        "failing threshold of 1 variable, the dashed vertical lines represent the "
         f"inspection window of {args.inspect_times[0]} - {args.inspect_times[-1]} s."
     )
     img_link = Path(*Path(args.img_dir).parts[-2:], Path(img_file).name)
@@ -534,8 +534,8 @@ def plot_pmin(args, ttest, img_file):
     img_caption = (
         "The minimum P value of all variables in both domains (land and ocean) as a "
         "function of model integration time plotted with a logarithmic y-scale. The "
-        "horizontal dashed grey line indicates the threshold for assigning an overall "
-        "pass or fail to a test ensemble; the vertical dashed lines represent the "
+        "dashed horizontal grey line indicates the threshold for assigning an overall "
+        "pass or fail to a test ensemble; the dashed vertical lines represent the "
         f"inspection window of {args.inspect_times[0]} - {args.inspect_times[-1]} s. "
         "see Wan et al. (2017) eqn. 8"
     )


### PR DESCRIPTION
### Actually fix [E3SM issue 4759](https://github.com/E3SM-Project/E3SM/issues/4759)
This makes the TSC test match the original intent of the time step convergence (TSC) test.  First, time steps are assessed for pass/fail, then an overall pass/fail is given.
- For a time step to fail, at least one variable has its null hypothesis rejected (i.e. RMSD difference has a p-value less than the threshold).
- For overall FAIL, at least two time steps within the inspection window must fail. 

### Additional improvements:
- Enhance TSC plots with threshold lines and caption
- Revise word order in figure captions
- Add pool_size argument for debugging mode