### PR TITLE
Implement FDR correction for MVK tests

### DIFF
--- a/evv4esm/__init__.py
+++ b/evv4esm/__init__.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright (c) 2018-2022 UT-BATTELLE, LLC
+# Copyright (c) 2018-2023 UT-BATTELLE, LLC
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -28,7 +28,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-__version_info__ = (0, 4, 0)
+__version_info__ = (0, 5, 0)
 __version__ = '.'.join(str(vi) for vi in __version_info__)
 
 PASS_COLOR = '#389933'

--- a/evv4esm/ensembles/e3sm.py
+++ b/evv4esm/ensembles/e3sm.py
@@ -72,8 +72,7 @@ def component_monthly_files(dir_, component, ninst, hist_name="h0", nmonth_max=1
     else:
         date_search = "????-??"
 
-def component_monthly_files(dir_, component, ninst, hist_name="hist", nmonth_max=24, date_style="short"):
-    base = "{d}/*{c}_????.{n}.????-??-??.nc".format(d=dir_, c=component, n=hist_name)
+    base = "{d}/*{c}_????.{n}.{ds}.nc".format(d=dir_, c=component, n=hist_name, ds=date_search)
     search = os.path.normpath(base)
     result = sorted(glob.glob(search))
 

--- a/evv4esm/ensembles/tools.py
+++ b/evv4esm/ensembles/tools.py
@@ -37,12 +37,15 @@ from matplotlib.gridspec import GridSpec
 
 from evv4esm import pf_color_picker, light_pf_color_picker
 
-def monthly_to_annual_avg(var_data, cal='ignore'):
-    if len(var_data) != 12:
-        raise ValueError('Error! There are 12 months in a year; '
-                         'you passed in {} monthly averages.'.format(len(var_data)))
 
-    if cal == 'ignore':
+def monthly_to_annual_avg(var_data, cal="ignore"):
+    if len(var_data) != 12:
+        raise ValueError(
+            "Error! There are 12 months in a year; "
+            "you passed in {} monthly averages.".format(len(var_data))
+        )
+
+    if cal == "ignore":
         # weight each month equally
         avg = np.average(var_data)
     else:
@@ -56,106 +59,126 @@ def prob_plot(
     ref,
     n_q,
     img_file,
-    test_name='Test',
-    ref_name='Ref.',
-    thing='annual global averages',
+    test_name="Test",
+    ref_name="Ref.",
+    thing="annual global averages",
     pf=None,
-    combine_hist=False
+    combine_hist=False,
 ):
     q = np.linspace(0, 100, n_q + 1)
     all_ = np.concatenate((test, ref))
     min_ = np.min(all_)
     max_ = np.max(all_)
 
-    if combine_hist:
-        fig = plt.figure(figsize=(10, 10))
-        gs = GridSpec(2, 2)
-        ax1 = fig.add_subplot(gs[0, 0])
-        ax2 = fig.add_subplot(gs[0, 1])
-        ax3 = fig.add_subplot(gs[1, :])
-        axes = [ax1, ax2, ax3]
-    else:
-        fig, ((ax1, ax2), (ax3, ax4)) = plt.subplots(2, 2, figsize=(10, 10))
-        axes = [ax1, ax2, ax3, ax4]
+    fig, ((ax1, ax2), (ax3, ax4)) = plt.subplots(2, 2, figsize=(10, 10))
+    axes = [ax1, ax2, ax3, ax4]
 
     _var = os.path.split(img_file)[-1].split(".")[0]
     fig.suptitle(_var)
 
-    plt.rc('font', family='serif')
+    plt.rc("font", family="serif")
 
-    ax1.set_title('Q-Q Plot')
-    ax1.set_xlabel('{} pdf'.format(ref_name))
-    ax1.set_ylabel('{} pdf'.format(test_name))
+    ax1.set_title("Q-Q Plot")
+    ax1.set_xlabel("{} pdf".format(ref_name))
+    ax1.set_ylabel("{} pdf".format(test_name))
 
     # NOTE: Axis switched here from Q-Q plot because cdf reflects about the 1-1 line
-    ax2.set_title('P-P Plot')
-    ax2.set_xlabel('{} cdf'.format(test_name))
-    ax2.set_ylabel('{} cdf'.format(ref_name))
+    ax2.set_title("P-P Plot")
+    ax2.set_xlabel("{} cdf".format(test_name))
+    ax2.set_ylabel("{} cdf".format(ref_name))
 
     norm_rng = [0.0, 1.0]
-    ax1.plot(norm_rng, norm_rng, 'gray', zorder=1)
+    ax1.plot(norm_rng, norm_rng, "gray", zorder=1)
     ax1.set_xlim(tuple(norm_rng))
     ax1.set_ylim(tuple(norm_rng))
     ax1.autoscale()
 
-    ax2.plot(norm_rng, norm_rng, 'gray', zorder=1)
+    ax2.plot(norm_rng, norm_rng, "gray", zorder=1)
     ax2.set_xlim(tuple(norm_rng))
     ax2.set_ylim(tuple(norm_rng))
     ax2.autoscale()
 
     if combine_hist:
-        ax3.set_title('Ensemble histogram')
+        ax3.set_title("Ensemble histogram")
+        ax4.set_title("Ensemble CDF")
     else:
-        ax3.set_title('{} pdf'.format(ref_name))
+        ax3.set_title("{} pdf".format(ref_name))
 
-        ax4.set_title('{} pdf'.format(test_name))
-        ax4.set_xlabel('Unity-based normalization of {}'.format(thing))
-        ax4.set_ylabel('Frequency')
+        ax4.set_title("{} pdf".format(test_name))
+        ax4.set_xlabel("Unity-based normalization of {}".format(thing))
+        ax4.set_ylabel("Frequency")
         ax4.set_xlim(tuple(norm_rng))
         ax4.autoscale()
 
-    ax3.set_ylabel('Frequency')
-    ax3.set_xlabel('Unity-based normalization of {}'.format(thing))
+    ax3.set_ylabel("Frequency")
+    ax3.set_xlabel("Unity-based normalization of {}".format(thing))
 
     ax3.set_xlim(tuple(norm_rng))
     ax3.autoscale()
+
+    ax4.set_ylabel("N Ensemble members")
+    ax4.set_xlabel("Unity-based normalization of {}".format(thing))
 
     # NOTE: Produce unity-based normalization of data for the Q-Q plots because
     #       matplotlib can't handle small absolute values or data ranges. See
     #          https://github.com/matplotlib/matplotlib/issues/6015
     bnds = np.linspace(min_, max_, n_q)
-    if not np.allclose(bnds, bnds[0], rtol=np.finfo(bnds[0]).eps, atol=np.finfo(bnds[0]).eps):
-        norm1 = (ref - min_) / (max_ - min_)
-        norm2 = (test - min_) / (max_ - min_)
+    if not np.allclose(
+        bnds, bnds[0], rtol=np.finfo(bnds[0]).eps, atol=np.finfo(bnds[0]).eps
+    ):
+        norm_ref = (ref - min_) / (max_ - min_)
+        norm_test = (test - min_) / (max_ - min_)
 
         # Create P-P plot
         ax1.scatter(
-            np.percentile(norm1, q),
-            np.percentile(norm2, q),
-            color=pf_color_picker.get(pf, '#1F77B4'),
-            zorder=2
+            np.percentile(norm_ref, q),
+            np.percentile(norm_test, q),
+            color=pf_color_picker.get(pf, "#1F77B4"),
+            zorder=2,
         )
         if combine_hist:
             # Plot joint histogram (groups test / ref side-by-side for each bin)
-            ax3.hist(
-                [norm1, norm2],
+            freq, bins, _ = ax3.hist(
+                [norm_ref, norm_test],
                 bins=n_q,
                 edgecolor="k",
-                label=[test_name, ref_name],
+                label=[ref_name, test_name],
                 color=[
                     pf_color_picker.get(pf, "#1F77B4"),
-                    light_pf_color_picker.get(pf, "#B55D1F")
+                    light_pf_color_picker.get(pf, "#B55D1F"),
                 ],
                 zorder=5,
             )
             ax3.legend()
+
+            cdf = freq.cumsum(axis=1)
+
+            ax4.plot(
+                bins,
+                [0, *cdf[0]],
+                color=pf_color_picker.get(pf, "#1F77B4"),
+                label=ref_name,
+            )
+            ax4.plot(
+                bins,
+                [0, *cdf[1]],
+                color=light_pf_color_picker.get(pf, "#B55D1F"),
+                label=test_name,
+            )
+            ax4.set_xlim(tuple(norm_rng))
+            ax4.legend()
+
         else:
-            ax3.hist(norm1, bins=n_q, color=pf_color_picker.get(pf, '#1F77B4'), edgecolor="k")
-            ax4.hist(norm2, bins=n_q, color=pf_color_picker.get(pf, '#1F77B4'), edgecolor="k")
+            ax3.hist(
+                norm_ref, bins=n_q, color=pf_color_picker.get(pf, "#1F77B4"), edgecolor="k"
+            )
+            ax4.hist(
+                norm_test, bins=n_q, color=pf_color_picker.get(pf, "#1F77B4"), edgecolor="k"
+            )
 
             # Check if these distributions are wildly different. If they are, use different
             # colours for the bottom axis? Otherwise set the scales to be the same [0, 1]
-            if abs(norm1.mean() - norm2.mean()) >= 0.5:
+            if abs(norm_ref.mean() - norm_test.mean()) >= 0.5:
                 ax3.tick_params(axis="x", colors="C0")
                 ax3.spines["bottom"].set_color("C0")
 
@@ -176,8 +199,9 @@ def prob_plot(
         ppxh = np.cumsum(ppxh)
         ppyh = np.cumsum(ppyh)
 
-        ax2.scatter(ppyh.values, ppxh.values,
-                    color=pf_color_picker.get(pf, '#1F77B4'), zorder=2)
+        ax2.scatter(
+            ppyh.values, ppxh.values, color=pf_color_picker.get(pf, "#1F77B4"), zorder=2
+        )
     else:
         # Define a text box if the data are not plottable
         const_axis_text = {
@@ -186,7 +210,7 @@ def prob_plot(
             "s": f"CONSTANT FIELD\nMIN: {min_:.4e}\nMAX: {max_:.4e}",
             "horizontalalignment": "center",
             "verticalalignment": "center",
-            "backgroundcolor": ax1.get_facecolor()
+            "backgroundcolor": ax1.get_facecolor(),
         }
         ax1.text(**const_axis_text)
         ax2.text(**const_axis_text)
@@ -196,10 +220,14 @@ def prob_plot(
                 bins=n_q,
                 edgecolor="k",
                 label=[test_name, ref_name],
-                color=[pf_color_picker.get(pf, "#1F77B4"), light_pf_color_picker.get(pf, "#B55D1F")],
+                color=[
+                    pf_color_picker.get(pf, "#1F77B4"),
+                    light_pf_color_picker.get(pf, "#B55D1F"),
+                ],
                 zorder=5,
             )
             ax3.legend()
+            ax4.legend()
         else:
             ax3.hist(
                 test,
@@ -222,7 +250,7 @@ def prob_plot(
 
     plt.tight_layout()
 
-    plt.savefig(img_file, bbox_inches='tight')
+    plt.savefig(img_file, bbox_inches="tight")
 
     plt.close(fig)
 

--- a/evv4esm/ensembles/tools.py
+++ b/evv4esm/ensembles/tools.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # coding=utf-8
-# Copyright (c) 2018 UT-BATTELLE, LLC
+# Copyright (c) 2018-2023 UT-BATTELLE, LLC
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/evv4esm/extensions/ks.py
+++ b/evv4esm/extensions/ks.py
@@ -43,7 +43,6 @@ critical number of rejecting variables. The critical value, α, is obtained from
 an empirically derived approximate null distribution of t using resampling
 techniques.
 """
-ALPHA = 0.05
 
 import argparse
 import os
@@ -154,6 +153,11 @@ def parse_args(args=None):
         default=False,
         help="Do not use FDR correction to compute global pass / fail, will ",
     )
+
+    parser.add_argument(
+        "--alpha", default=0.05, type=float, help="Alpha threshold for pass / fail"
+    )
+
     args, _ = parser.parse_known_args(args)
 
     # use config file arguments, but override with command line arguments
@@ -391,10 +395,10 @@ def compute_details(annual_avgs, common_vars, args):
     # Convert to a Dataframe, transposed so that the index is the variable name
     detail_df = pd.DataFrame(details).T
     # Create a null hypothesis rejection column for un-corrected p-values
-    detail_df["h0_uc"] = detail_df["K-S test p-val"] < ALPHA
+    detail_df["h0_uc"] = detail_df["K-S test p-val"] < args.alpha
 
     (detail_df["h0_c"], detail_df["pval_c"]) = smm.fdrcorrection(
-        detail_df["K-S test p-val"], alpha=ALPHA, method="indep", is_sorted=False
+        detail_df["K-S test p-val"], alpha=args.alpha, method="n", is_sorted=False
     )
 
     if args.uncorrected:

--- a/evv4esm/extensions/ks.py
+++ b/evv4esm/extensions/ks.py
@@ -137,6 +137,10 @@ def parse_args(args=None):
     parser.add_argument("--img-dir", default=os.getcwd(), help="Image output location.")
 
     parser.add_argument(
+        "--img-fmt", default="png", type=str, help="Format for output images"
+    )
+
+    parser.add_argument(
         "--component", default="eam", help="Model component name (e.g. eam, cam, ...)"
     )
 
@@ -443,7 +447,7 @@ def main(args):
         ).monthly_mean.values
 
         img_file = os.path.relpath(
-            os.path.join(args.img_dir, var + ".png"), os.getcwd()
+            os.path.join(args.img_dir, f"{var}.{args.img_fmt}"), os.getcwd()
         )
         prob_plot(
             annuals_1,

--- a/evv4esm/extensions/ks.py
+++ b/evv4esm/extensions/ks.py
@@ -68,70 +68,83 @@ from evv4esm.utils import bib2html
 
 
 def variable_set(name):
-    var_sets = fn.read_json(os.path.join(os.path.dirname(__file__),
-                                         'ks_vars.json'))
+    var_sets = fn.read_json(os.path.join(os.path.dirname(__file__), "ks_vars.json"))
     try:
         the_set = var_sets[name.lower()]
         return set(the_set)
     except KeyError as e:
-        six.raise_from(argparse.ArgumentTypeError(
-                'Unknown variable set! Known sets are {}'.format(
-                        var_sets.keys()
-                )), e)
+        six.raise_from(
+            argparse.ArgumentTypeError(
+                "Unknown variable set! Known sets are {}".format(var_sets.keys())
+            ),
+            e,
+        )
 
 
 def parse_args(args=None):
-    parser = argparse.ArgumentParser(description=__doc__,
-                                     formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
 
-    parser.add_argument('-c', '--config',
-                        type=fn.read_json,
-                        help='A JSON config file containing a `ks` dictionary defining ' +
-                             'the options. NOTE: command line options will override file options.')
+    parser.add_argument(
+        "-c",
+        "--config",
+        type=fn.read_json,
+        help="A JSON config file containing a `ks` dictionary defining "
+        + "the options. NOTE: command line options will override file options.",
+    )
 
-    parser.add_argument('--test-case',
-                        default='default',
-                        help='Name of the test case.')
+    parser.add_argument("--test-case", default="default", help="Name of the test case.")
 
-    parser.add_argument('--test-dir',
-                        default=os.path.join(os.getcwd(), 'archive'),
-                        help='Location of the test case run files.')
+    parser.add_argument(
+        "--test-dir",
+        default=os.path.join(os.getcwd(), "archive"),
+        help="Location of the test case run files.",
+    )
 
-    parser.add_argument('--ref-case',
-                        default='fast',
-                        help='Name of the reference case.')
+    parser.add_argument(
+        "--ref-case", default="fast", help="Name of the reference case."
+    )
 
-    parser.add_argument('--ref-dir',
-                        default=os.path.join(os.getcwd(), 'archive'),
-                        help='Location of the reference case run files.')
+    parser.add_argument(
+        "--ref-dir",
+        default=os.path.join(os.getcwd(), "archive"),
+        help="Location of the reference case run files.",
+    )
 
-    parser.add_argument('--var-set',
-                        default='default', type=variable_set,
-                        help='Name of the variable set to analyze.')
+    parser.add_argument(
+        "--var-set",
+        default="default",
+        type=variable_set,
+        help="Name of the variable set to analyze.",
+    )
 
-    parser.add_argument('--ninst',
-                        default=30, type=int,
-                        help='The number of instances (should be the same for '
-                             'both cases).')
+    parser.add_argument(
+        "--ninst",
+        default=30,
+        type=int,
+        help="The number of instances (should be the same for " "both cases).",
+    )
 
-    parser.add_argument('--critical',
-                        default=13, type=float,
-                        help='The critical value (desired significance level) for rejecting the ' +
-                        'null hypothesis.')
+    parser.add_argument(
+        "--critical",
+        default=13,
+        type=float,
+        help="The critical value (desired significance level) for rejecting the "
+        + "null hypothesis.",
+    )
 
-    parser.add_argument('--img-dir',
-                        default=os.getcwd(),
-                        help='Image output location.')
+    parser.add_argument("--img-dir", default=os.getcwd(), help="Image output location.")
 
-    parser.add_argument('--component',
-                        default='eam',
-                        help='Model component name (e.g. eam, cam, ...)')
+    parser.add_argument(
+        "--component", default="eam", help="Model component name (e.g. eam, cam, ...)"
+    )
 
     parser.add_argument(
         "--correct",
         action="store_true",
         default=False,
-        help="Use FDR correction to compute global pass / fail"
+        help="Use FDR correction to compute global pass / fail",
     )
     args, _ = parser.parse_known_args(args)
 
@@ -139,14 +152,18 @@ def parse_args(args=None):
     if args.config:
         default_args = parser.parse_args([])
 
-        for key, val, in vars(args).items():
+        for (
+            key,
+            val,
+        ) in vars(args).items():
             if val != vars(default_args)[key]:
-                args.config['ks'][key] = val
+                args.config["ks"][key] = val
 
         config_arg_list = []
         _ = [
-            config_arg_list.extend(['--'+key, str(val)])
-            for key, val in args.config['ks'].items() if key != 'config'
+            config_arg_list.extend(["--" + key, str(val)])
+            for key, val in args.config["ks"].items()
+            if key != "config"
         ]
         args, _ = parser.parse_known_args(config_arg_list)
 
@@ -169,6 +186,7 @@ def col_fmt(dat):
 
     return _out
 
+
 def run(name, config):
     """
     Runs the analysis.
@@ -182,11 +200,11 @@ def run(name, config):
     """
 
     config_arg_list = []
-    [config_arg_list.extend(['--'+key, str(val)]) for key, val in config.items()]
+    [config_arg_list.extend(["--" + key, str(val)]) for key, val in config.items()]
 
     args = parse_args(config_arg_list)
 
-    args.img_dir = os.path.join(livvkit.output_dir, 'validation', 'imgs', name)
+    args.img_dir = os.path.join(livvkit.output_dir, "validation", "imgs", name)
     fn.mkdir_p(args.img_dir)
 
     details, img_gal = main(args)
@@ -210,17 +228,13 @@ def run(name, config):
     tables = [
         el.Table("Rejected", data=table_data[table_data["h0"] == "reject"]),
         el.Table("Accepted", data=table_data[table_data["h0"] == "accept"]),
-        el.Table("Null", data=table_data[~table_data["h0"].isin(["accept", "reject"])])
+        el.Table("Null", data=table_data[~table_data["h0"].isin(["accept", "reject"])]),
     ]
 
-    bib_html = bib2html(os.path.join(os.path.dirname(__file__), 'ks.bib'))
+    bib_html = bib2html(os.path.join(os.path.dirname(__file__), "ks.bib"))
 
     tabs = el.Tabs(
-        {
-            "Figures": img_gal,
-            "Details": tables,
-            "References": [el.RawHTML(bib_html)]
-        }
+        {"Figures": img_gal, "Details": tables, "References": [el.RawHTML(bib_html)]}
     )
     rejects = [var for var, dat in details.items() if dat["h0"] == "reject"]
     if args.correct:
@@ -233,19 +247,21 @@ def run(name, config):
         data=OrderedDict(
             {
                 # 'Test status': ['pass' if len(rejects) < args.critical else 'fail'],
-                'Test status': ['pass' if len(rejects) < critical else 'fail'],
-                'Variables analyzed': [len(details.keys())],
-                'Rejecting': [len(rejects)],
-                'Critical value': [int(critical)],
-                'Ensembles': [
-                    'statistically identical' if len(rejects) < critical else 'statistically different'
-                ]
+                "Test status": ["pass" if len(rejects) < critical else "fail"],
+                "Variables analyzed": [len(details.keys())],
+                "Rejecting": [len(rejects)],
+                "Critical value": [int(critical)],
+                "Ensembles": [
+                    "statistically identical"
+                    if len(rejects) < critical
+                    else "statistically different"
+                ],
             }
-        )
+        ),
     )
 
     # FIXME: Put into a ___ function
-    page = el.Page(name, __doc__.replace('\n\n', '<br><br>'), elements=[results, tabs])
+    page = el.Page(name, __doc__.replace("\n\n", "<br><br>"), elements=[results, tabs])
     return page
 
 
@@ -254,50 +270,54 @@ def case_files(args):
     key1 = args.test_case
     key2 = args.ref_case
     if args.test_case == args.ref_case:
-        key1 += '1'
-        key2 += '2'
+        key1 += "1"
+        key2 += "2"
 
-    f_sets = {key1: e3sm.component_monthly_files(args.test_dir, args.component, args.ninst),
-              key2: e3sm.component_monthly_files(args.ref_dir, args.component, args.ninst)}
+    f_sets = {
+        key1: e3sm.component_monthly_files(args.test_dir, args.component, args.ninst),
+        key2: e3sm.component_monthly_files(args.ref_dir, args.component, args.ninst),
+    }
 
     for key in f_sets:
         # Require case files for at least the last 12 months.
         if any(list(map(lambda x: x == [], f_sets[key].values()))[-12:]):
-            raise EVVException('Could not find all the required case files for case: {}'.format(key))
+            raise EVVException(
+                "Could not find all the required case files for case: {}".format(key)
+            )
 
     return f_sets, key1, key2
 
 
 def print_summary(summary):
-    print('    Kolmogorov-Smirnov Test: {}'.format(summary['']['Case']))
-    print('      Variables analyzed: {}'.format(summary['']['Variables analyzed']))
-    print('      Rejecting: {}'.format(summary['']['Rejecting']))
-    print('      Critical value: {}'.format(summary['']['Critical value']))
-    print('      Ensembles: {}'.format(summary['']['Ensembles']))
-    print('      Test status: {}\n'.format(summary['']['Test status']))
+    print("    Kolmogorov-Smirnov Test: {}".format(summary[""]["Case"]))
+    print("      Variables analyzed: {}".format(summary[""]["Variables analyzed"]))
+    print("      Rejecting: {}".format(summary[""]["Rejecting"]))
+    print("      Critical value: {}".format(summary[""]["Critical value"]))
+    print("      Ensembles: {}".format(summary[""]["Ensembles"]))
+    print("      Test status: {}\n".format(summary[""]["Test status"]))
 
 
 def print_details(details):
     for set_ in details:
-        print('-'*80)
+        print("-" * 80)
         print(set_)
-        print('-'*80)
+        print("-" * 80)
         pprint(details[set_])
 
 
 def summarize_result(results_page):
-    summary = {'Case': results_page.title}
+    summary = {"Case": results_page.title}
 
     for elem in results_page.elements:
         if isinstance(elem, el.Table) and elem.title == "Results":
-            summary['Test status'] = elem.data['Test status'][0]
-            summary['Variables analyzed'] = elem.data['Variables analyzed'][0]
-            summary['Rejecting'] = elem.data['Rejecting'][0]
-            summary['Critical value'] = elem.data['Critical value'][0]
-            summary['Ensembles'] = elem.data['Ensembles'][0]
+            summary["Test status"] = elem.data["Test status"][0]
+            summary["Variables analyzed"] = elem.data["Variables analyzed"][0]
+            summary["Rejecting"] = elem.data["Rejecting"][0]
+            summary["Critical value"] = elem.data["Critical value"][0]
+            summary["Ensembles"] = elem.data["Ensembles"][0]
             break
 
-    return {'': summary}
+    return {"": summary}
 
 
 def populate_metadata():
@@ -306,23 +326,34 @@ def populate_metadata():
     is done by this module's run method
     """
 
-    metadata = {'Type': 'ValSummary',
-                'Title': 'Validation',
-                'TableTitle': 'Kolmogorov-Smirnov test',
-                'Headers': ['Test status', 'Variables analyzed', 'Rejecting', 'Critical value', 'Ensembles']}
+    metadata = {
+        "Type": "ValSummary",
+        "Title": "Validation",
+        "TableTitle": "Kolmogorov-Smirnov test",
+        "Headers": [
+            "Test status",
+            "Variables analyzed",
+            "Rejecting",
+            "Critical value",
+            "Ensembles",
+        ],
+    }
     return metadata
 
 
 def compute_details(annual_avgs, common_vars, args):
-    """Compute the detail table, perform a T Test and K-S test for each variable.
-    """
+    """Compute the detail table, perform a T Test and K-S test for each variable."""
     details = LIVVDict()
     for var in sorted(common_vars):
-        annuals_1 = annual_avgs.query('case == @args.test_case & variable == @var').monthly_mean.values
-        annuals_2 = annual_avgs.query('case == @args.ref_case & variable == @var').monthly_mean.values
+        annuals_1 = annual_avgs.query(
+            "case == @args.test_case & variable == @var"
+        ).monthly_mean.values
+        annuals_2 = annual_avgs.query(
+            "case == @args.ref_case & variable == @var"
+        ).monthly_mean.values
 
         ttest_t, ttest_p = stats.ttest_ind(
-            annuals_1, annuals_2, equal_var=False, nan_policy=str('omit')
+            annuals_1, annuals_2, equal_var=False, nan_policy=str("omit")
         )
         ks_d, ks_p = stats.ks_2samp(annuals_1, annuals_2)
 
@@ -333,20 +364,20 @@ def compute_details(annual_avgs, common_vars, args):
         details[var]["T test stat"] = ttest_t
         details[var]["T test p-val"] = ttest_p
 
-        details[var]['K-S test stat'] = ks_d
-        details[var]['K-S test p-val'] = ks_p
+        details[var]["K-S test stat"] = ks_d
+        details[var]["K-S test p-val"] = ks_p
 
-        details[var]['mean test case'] = annuals_1.mean()
-        details[var]['mean ref. case'] = annuals_2.mean()
+        details[var]["mean test case"] = annuals_1.mean()
+        details[var]["mean ref. case"] = annuals_2.mean()
 
-        details[var]['max test case'] = annuals_1.max()
-        details[var]['max ref. case'] = annuals_2.max()
+        details[var]["max test case"] = annuals_1.max()
+        details[var]["max ref. case"] = annuals_2.max()
 
-        details[var]['min test case'] = annuals_1.min()
-        details[var]['min ref. case'] = annuals_2.min()
+        details[var]["min test case"] = annuals_1.min()
+        details[var]["min ref. case"] = annuals_2.min()
 
-        details[var]['std test case'] = annuals_1.std()
-        details[var]['std ref. case'] = annuals_2.std()
+        details[var]["std test case"] = annuals_1.std()
+        details[var]["std ref. case"] = annuals_2.std()
 
     # Now that the details have been computed, perform the FDR correction
     # Convert to a Dataframe, transposed so that the index is the variable name
@@ -366,12 +397,12 @@ def compute_details(annual_avgs, common_vars, args):
     for var in common_vars:
         details[var]["K-S test p-val"] = detail_df.loc[var, "pval_c"]
 
-        if details[var]['T test stat'] is None:
-            details[var]['h0'] = '-'
+        if details[var]["T test stat"] is None:
+            details[var]["h0"] = "-"
         elif detail_df.loc[var, _testkey]:
-            details[var]['h0'] = 'reject'
+            details[var]["h0"] = "reject"
         else:
-            details[var]['h0'] = 'accept'
+            details[var]["h0"] = "accept"
 
     return details
 
@@ -383,24 +414,37 @@ def main(args):
         args.ref_case = key2
 
     monthly_avgs = e3sm.gather_monthly_averages(ens_files, args.var_set)
-    annual_avgs = monthly_avgs.groupby(['case', 'variable', 'instance']
-                                       ).monthly_mean.aggregate(monthly_to_annual_avg).reset_index()
+    annual_avgs = (
+        monthly_avgs.groupby(["case", "variable", "instance"])
+        .monthly_mean.aggregate(monthly_to_annual_avg)
+        .reset_index()
+    )
 
     # now, we got the data, so let's get some stats
     test_set = set(monthly_avgs[monthly_avgs.case == args.test_case].variable.unique())
     ref_set = set(monthly_avgs[monthly_avgs.case == args.ref_case].variable.unique())
     common_vars = list(test_set & ref_set)
     if not common_vars:
-        raise EVVException('No common variables between {} and {} to analyze!'.format(args.test_case, args.ref_case))
+        raise EVVException(
+            "No common variables between {} and {} to analyze!".format(
+                args.test_case, args.ref_case
+            )
+        )
 
     images = {"accept": [], "reject": [], "-": []}
     details = compute_details(annual_avgs, common_vars, args)
 
     for var in sorted(common_vars):
-        annuals_1 = annual_avgs.query('case == @args.test_case & variable == @var').monthly_mean.values
-        annuals_2 = annual_avgs.query('case == @args.ref_case & variable == @var').monthly_mean.values
+        annuals_1 = annual_avgs.query(
+            "case == @args.test_case & variable == @var"
+        ).monthly_mean.values
+        annuals_2 = annual_avgs.query(
+            "case == @args.ref_case & variable == @var"
+        ).monthly_mean.values
 
-        img_file = os.path.relpath(os.path.join(args.img_dir, var + '.png'), os.getcwd())
+        img_file = os.path.relpath(
+            os.path.join(args.img_dir, var + ".png"), os.getcwd()
+        )
         prob_plot(
             annuals_1,
             annuals_2,
@@ -408,30 +452,40 @@ def main(args):
             img_file,
             test_name=args.test_case,
             ref_name=args.ref_case,
-            pf=details[var]['h0'],
-            combine_hist=True
+            pf=details[var]["h0"],
+            combine_hist=True,
         )
-        _desc = monthly_avgs.query('case == @args.test_case & variable == @var').desc.values[0]
-        img_desc = 'Mean annual global average of {var}{desc} for <em>{testcase}</em> ' \
-                   'is {testmean:.3e} and for <em>{refcase}</em> is {refmean:.3e}. ' \
-                   'Pass (fail) is indicated by {cpass} ({cfail}) coloring of the ' \
-                   'plot markers and bars.'.format(var=var,
-                                                   desc=_desc,
-                                                   testcase=args.test_case,
-                                                   testmean=details[var]['mean test case'],
-                                                   refcase=args.ref_case,
-                                                   refmean=details[var]['mean ref. case'],
-                                                   cfail=human_color_names['fail'][0],
-                                                   cpass=human_color_names['pass'][0])
+        _desc = monthly_avgs.query(
+            "case == @args.test_case & variable == @var"
+        ).desc.values[0]
+        img_desc = (
+            "Mean annual global average of {var}{desc} for <em>{testcase}</em> "
+            "is {testmean:.3e} and for <em>{refcase}</em> is {refmean:.3e}. "
+            "Pass (fail) is indicated by {cpass} ({cfail}) coloring of the "
+            "plot markers and bars.".format(
+                var=var,
+                desc=_desc,
+                testcase=args.test_case,
+                testmean=details[var]["mean test case"],
+                refcase=args.ref_case,
+                refmean=details[var]["mean ref. case"],
+                cfail=human_color_names["fail"][0],
+                cpass=human_color_names["pass"][0],
+            )
+        )
 
         img_link = Path(*Path(args.img_dir).parts[-2:], Path(img_file).name)
-        _img = el.Image(var, img_desc, img_link, relative_to="", group=details[var]['h0'])
-        images[details[var]['h0']].append(_img)
+        _img = el.Image(
+            var, img_desc, img_link, relative_to="", group=details[var]["h0"]
+        )
+        images[details[var]["h0"]].append(_img)
 
     gals = []
     for group in ["reject", "accept", "-"]:
         _group_name = {
-            "reject": "Failed variables", "accept": "Passed variables", "-": "Null variables"
+            "reject": "Failed variables",
+            "accept": "Passed variables",
+            "-": "Null variables",
         }
         if images[group]:
             gals.append(el.Gallery(_group_name[group], images[group]))
@@ -439,5 +493,5 @@ def main(args):
     return details, gals
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     print_details(main(parse_args()))

--- a/evv4esm/extensions/ks.py
+++ b/evv4esm/extensions/ks.py
@@ -129,9 +129,12 @@ def parse_args(args=None):
     parser.add_argument(
         "--critical",
         default=13,
-        type=float,
-        help="The critical value (desired significance level) for rejecting the "
-        + "null hypothesis.",
+        type=int,
+        help=(
+            "The critical value (desired significance level) for rejecting the "
+            "null hypothesis. Only used when --uncorrected / -u flag is passed. "
+            "Otherwise the critical value is 1."
+        ),
     )
 
     parser.add_argument("--img-dir", default=os.getcwd(), help="Image output location.")
@@ -145,10 +148,11 @@ def parse_args(args=None):
     )
 
     parser.add_argument(
-        "--correct",
+        "--uncorrected",
+        "-u",
         action="store_true",
         default=False,
-        help="Use FDR correction to compute global pass / fail",
+        help="Do not use FDR correction to compute global pass / fail, will ",
     )
     args, _ = parser.parse_known_args(args)
 
@@ -241,10 +245,10 @@ def run(name, config):
         {"Figures": img_gal, "Details": tables, "References": [el.RawHTML(bib_html)]}
     )
     rejects = [var for var, dat in details.items() if dat["h0"] == "reject"]
-    if args.correct:
-        critical = 1
-    else:
+    if args.uncorrected:
         critical = args.critical
+    else:
+        critical = 1
 
     results = el.Table(
         title="Results",
@@ -393,10 +397,10 @@ def compute_details(annual_avgs, common_vars, args):
         detail_df["K-S test p-val"], alpha=ALPHA, method="indep", is_sorted=False
     )
 
-    if args.correct:
-        _testkey = "h0_c"
-    else:
+    if args.uncorrected:
         _testkey = "h0_uc"
+    else:
+        _testkey = "h0_c"
 
     for var in common_vars:
         details[var]["K-S test p-val"] = detail_df.loc[var, "pval_c"]

--- a/evv4esm/extensions/ks.py
+++ b/evv4esm/extensions/ks.py
@@ -224,7 +224,7 @@ def run(name, config):
     )
     rejects = [var for var, dat in details.items() if dat["h0"] == "reject"]
     if args.correct:
-        critical = ALPHA * len(details.keys())
+        critical = 1
     else:
         critical = args.critical
 
@@ -354,18 +354,9 @@ def compute_details(annual_avgs, common_vars, args):
     # Create a null hypothesis rejection column for un-corrected p-values
     detail_df["h0_uc"] = detail_df["K-S test p-val"] < ALPHA
 
-    (
-        detail_df["h0_c"],
-        detail_df["pval_c"],
-        detail_df["alpha_out"],
-        detail_df["alpha_in"]
-    ) = zip(*detail_df["K-S test p-val"].apply(
-        smm.multipletests, alpha=ALPHA, method="holm", is_sorted=False)
+    (detail_df["h0_c"], detail_df["pval_c"]) = smm.fdrcorrection(
+        detail_df["K-S test p-val"], alpha=ALPHA, method="indep", is_sorted=False
     )
-
-    for _key in ["h0_c", "pval_c"]:
-        # These variables return lists not floats, fix that
-        detail_df[_key] = detail_df[_key].apply(lambda x: x[0])
 
     if args.correct:
         _testkey = "h0_c"

--- a/evv4esm/extensions/kso.py
+++ b/evv4esm/extensions/kso.py
@@ -132,6 +132,10 @@ def parse_args(args=None):
     parser.add_argument("--img-dir", default=os.getcwd(), help="Image output location.")
 
     parser.add_argument(
+        "--img-fmt", default="png", type=str, help="Format for output images"
+    )
+
+    parser.add_argument(
         "--component", default="mpaso", help="Model component name (e.g. eam, cam, ...)"
     )
 
@@ -433,7 +437,7 @@ def main(args):
         details[var]["h0"] = test_result
 
         img_file = os.path.relpath(
-            os.path.join(args.img_dir, var + ".png"), os.getcwd()
+            os.path.join(args.img_dir, f"{var}.{args.img_fmt}"), os.getcwd()
         )
 
         # Plot ensemble histogram / q-q, p-p plot of

--- a/evv4esm/extensions/kso.py
+++ b/evv4esm/extensions/kso.py
@@ -376,9 +376,7 @@ def main(args):
     # performing the test (across ensemble members) to be the last dimension
     # (e.g. [nCells, nLevels, nEns]) this is why load_mpas_climatology_ensemble
     # returns data in this way
-    ks_test = np.vectorize(
-        stats.mstats.ks_2samp, signature="(n),(n)->(),()"
-    )
+    ks_test = np.vectorize(stats.mstats.ks_2samp, signature="(n),(n)->(),()")
 
     images = {"accept": [], "reject": [], "-": []}
     details = LIVVDict()
@@ -448,6 +446,7 @@ def main(args):
             test_name=args.test_case,
             ref_name=args.ref_case,
             pf=details[var]["h0"],
+            combine_hist=True,
         )
 
         img_desc = (

--- a/evv4esm/extensions/kso.py
+++ b/evv4esm/extensions/kso.py
@@ -400,7 +400,7 @@ def main(args):
 
         null_reject_pre_correct = np.sum(np.where(p_val <= args.alpha, 1, 0))
         _, p_val = smm.fdrcorrection(
-            p_val.flatten(), alpha=args.alpha, method="indep", is_sorted=False
+            p_val.flatten(), alpha=args.alpha, method="n", is_sorted=False
         )
         null_reject_post_correct = np.sum(np.where(p_val <= args.alpha, 1, 0))
 

--- a/evv4esm/extensions/pg.py
+++ b/evv4esm/extensions/pg.py
@@ -253,9 +253,8 @@ def main(args):
     pge_ends_comp = comp_rmse[:, :, -1]
 
     # run the t-test
-    pge_ends_cld = pge_ends_cld.flatten()
-    pge_ends_comp = pge_ends_comp.flatten()
-
+    pge_ends_cld = pge_ends_cld.flatten().astype(np.float32)
+    pge_ends_comp = pge_ends_comp.flatten().astype(np.float32)
     t_stat, p_val = stats.ttest_ind(pge_ends_cld, pge_ends_comp)
 
     if np.isnan((t_stat, p_val)).any() or np.isinf((t_stat, p_val)).any():

--- a/evv4esm/resources/js/common.js
+++ b/evv4esm/resources/js/common.js
@@ -32,13 +32,35 @@
 /**
  * When the page is loaded, do some stuff
  */
-$(document).ready(function() {
+$(document).ready(function () {
     drawNav();
     drawContent();
 });
 
-$(window).load(function() {
+$(window).load(function () {
     $('img.caption').captionjs();
+
+    // Make tables sortable: see:
+    // https://stackoverflow.com/questions/14267781/sorting-html-table-with-javascript
+    const getCellValue = (tr, idx) => tr.children[idx].innerText || tr.children[idx].textContent;
+
+    const comparer = (idx, asc) => (a, b) => ((v1, v2) =>
+        v1 !== '' && v2 !== '' && !isNaN(v1) && !isNaN(v2) ? v1 - v2 : v1.toString().localeCompare(v2)
+    )(getCellValue(asc ? a : b, idx), getCellValue(asc ? b : a, idx));
+
+    // do the work...
+    document.querySelectorAll('th').forEach(
+        th => th.addEventListener(
+            'click', (
+            () => {
+                const table = th.closest('table');
+                Array.from(table.querySelectorAll('tr:nth-child(n+2)'))
+                    .sort(comparer(Array.from(th.parentNode.children).indexOf(th), this.asc = !this.asc))
+                    .forEach(tr => table.appendChild(tr));
+            }
+        )
+        )
+    );
 });
 
 
@@ -49,17 +71,17 @@ $(window).load(function() {
 function drawNav() {
     // Get the dataset, to do so the html page must have the `indexPath` variable defined
     var html = "";
-    var getUrl = window.location.href.substr(0,window.location.href.lastIndexOf('/')+1);
+    var getUrl = window.location.href.substr(0, window.location.href.lastIndexOf('/') + 1);
     var data = loadJSON(getUrl + indexPath + '/index.json');
     data = data["Page"];
     // Go through each category: numerics, verification, performance, and validation
     for (var el_idx in data["elements"]) {
         if (data["elements"][el_idx] != null && Object.keys(data["elements"][el_idx]["Table"]["data"]).length > 0) {
             html += "<h3>" + data["elements"][el_idx]["Table"]["title"] + "</h3>\n";
-            var testList = Array.from(new Set( data["elements"][el_idx]["Table"]["index"])).sort();
+            var testList = Array.from(new Set(data["elements"][el_idx]["Table"]["index"])).sort();
             for (var idx in testList) {
                 html += "<a href=" + indexPath + "/" + data["elements"][el_idx]["Table"]["title"].toLowerCase() +
-                        "/" + testList[idx] + ".html>" + testList[idx] + "</a></br>";
+                    "/" + testList[idx] + ".html>" + testList[idx] + "</a></br>";
             }
         }
     }
@@ -74,7 +96,7 @@ function drawNav() {
 function drawContent() {
     // Load the data and add header information
     var html_file = window.location.href.substr(
-            window.location.href.lastIndexOf("/")+1).split("#")[0].replace(".html", "");
+        window.location.href.lastIndexOf("/") + 1).split("#")[0].replace(".html", "");
     // Assume index.html if empty page name
     if (html_file === "") {
         html_file = "index";
@@ -95,7 +117,7 @@ function loadJSON(path) {
         'global': false,
         'url': path,
         'dataType': "json",
-        'success': function(json) {
+        'success': function (json) {
             data = json;
         }
     });

--- a/evv4esm/resources/js/common.js
+++ b/evv4esm/resources/js/common.js
@@ -1,5 +1,5 @@
 /*
-/ Copyright (c) 2015-2018, UT-BATTELLE, LLC
+/ Copyright (c) 2015-2023, UT-BATTELLE, LLC
 / All rights reserved.
 / 
 / Redistribution and use in source and binary forms, with or without

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ setup(
           'netCDF4',
           'matplotlib',
           'pybtex',
-          'statsmodels',
+          'statsmodels==0.14.0',
           ],
 
       packages=[


### PR DESCRIPTION
Major updates
-
- Implement Benjamini and Yekutieli (2001) method for false discovery rate correction in the MVK test
   - This takes advantage of multiple concurrent tests to reduce erroneous rejection of null hypotheses
   - P-values are adjusted then compared against the global significance level (0.05 by default), if _any_ are below the threshold, the tests are considered climate changing (i.e. the ensembles are different)
  
Minor improvements
-
- Add argument for output figure file format
- Use combined histogram plot for KS-ocean and KS-atmosphere tests
- Add sort-able tables to output

Bug fixes
-
- Cast arrays to float, fix bug for loading new PGN data
- Fix doubly defined function
